### PR TITLE
Check HTTP response codes, and parse RFC7807 problem reports.

### DIFF
--- a/src/letsencrypt_api.erl
+++ b/src/letsencrypt_api.erl
@@ -248,6 +248,7 @@ problem_type(<<"urn:ietf:params:acme:error:", X/binary>>) ->
 	 <<"connection">> -> connection;
 	 <<"dnssec">> -> dnssec;
 	 <<"invalidContact">> -> invalidContact;
+	 <<"invalidEmail">> -> invalidContact; % Boulder-specific difference
 	 <<"malformed">> -> malformed;
 	 <<"rateLimited">> -> rateLimited;
 	 <<"rejectedIdentifier">> -> rejectedIdentifier;


### PR DESCRIPTION
Currently, if something goes wrong and an HTTP request fails or the ACME server rejects a request, the status code will be ignored and the response will be parsed as JSON, BER, or whatever. This patch adds minimal checking for HTTP errors, and in the case of [RFC7807](https://tools.ietf.org/html/rfc7807)-formatted [error responses](https://github.com/ietf-wg-acme/acme/blob/master/draft-ietf-acme-acme.md#errors), parses the problem report into a more convenient erlang term representation.

`rebar3 ct` passes. You can test the error-handling and -parsing functionality by, e.g., removing the rate-limit overrides in boulder's `test/rate-limit-policies.yml` and rerunning the common tests against that boulder instance.
