### PR TITLE
Allow multiple letsencrypt clients.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rel/example_project
 .rebar
 .rebar3
 _build
+compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ ebin
 rel/example_project
 .concrete/DEV_MODE
 .rebar
+.rebar3
 _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ dist: trusty
 language: erlang
 
 otp_release:
-    - 19.0
-    - 18.2.1
+    # - 19.0
+    # - 18.2.1
     - 17.5
 
 services:

--- a/src/letsencrypt.erl
+++ b/src/letsencrypt.erl
@@ -226,7 +226,7 @@ make_cert_bg(FSM, Domain, Opts=#{async := Async}) ->
 
 -spec wait_valid(fsm_ref(), 0..10, 0..10) -> ok|{error, any()}.
 wait_valid(_FSM, 0, _) ->
-    ?debug("wait_valid timeout~n", [Err]),
+    ?debug("wait_valid timeout~n", []),
     {error, timeout};
 wait_valid(FSM, Cnt, Max) ->
     case gen_fsm:sync_send_event(FSM, check, 15000) of

--- a/src/letsencrypt_api.erl
+++ b/src/letsencrypt_api.erl
@@ -25,7 +25,7 @@
     -define(AGREEMENT_URL  , <<"http://boulder:4000/terms/v1">>).
     -define(debug(Fmt, Args), io:format(Fmt, Args)).
 -else.
-    -define(AGREEMENT_URL  , <<"https://letsencrypt.org/documents/LE-SA-v1.1.1-August-1-2016.pdf">>).
+    -define(AGREEMENT_URL  , <<"https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf">>).
     -define(debug(Fmt, Args), ok).
 -endif.
 

--- a/src/letsencrypt_api.erl
+++ b/src/letsencrypt_api.erl
@@ -151,6 +151,8 @@ challenge(post, Conn, Path, Key, Jws, Thumbprint) ->
 -spec challenge(status, pid(), string()) -> {'ok'|'invalid', atom()|binary()}.
 challenge(status, Conn, Path) ->
     {ok, Resp} = shotgun:get(Conn, Path, #{}),
+    ?debug("challenge(status, _, ~p) => ~p~n", [Path, Resp]),
+
     #{body := Body} = Resp,
     %io:format("challenge status: ~p~n", [Body]),
 

--- a/src/letsencrypt_ssl.erl
+++ b/src/letsencrypt_ssl.erl
@@ -18,7 +18,6 @@
 -export([private_key/2, cert_request/3, cert_autosigned/3, certificate/4]).
 
 -include_lib("public_key/include/public_key.hrl").
--import(letsencrypt_utils, [bin/1]).
 
 % create key
 -spec private_key(undefined|{new, string()}|string(), string()) -> letsencrypt:ssl_privatekey().

--- a/test/letsencrypt_SUITE.erl
+++ b/test/letsencrypt_SUITE.erl
@@ -152,7 +152,7 @@ priv_COMMON(Mode, Config, StartOpts) ->
     Async = maps:get(async, Opts, true),
     ?DEBUG("async: ~p, opts: ~p, startopts: ~p", [Async, Opts, StartOpts]),
 
-    {ok, Pid} = letsencrypt:start([{mode, Mode}, staging, {cert_path, "/tmp"}]++StartOpts),
+    {ok, _Pid} = letsencrypt:start([{mode, Mode}, staging, {cert_path, "/tmp"}]++StartOpts),
 
     R3 = case Async of
         false ->
@@ -175,7 +175,7 @@ priv_COMMON(Mode, Config, StartOpts) ->
     letsencrypt:stop(),
     % checking certificate returned
     ?DEBUG("result: ~p", [R3]),
-    {ok, #{cert := Cert, key := Key}} = R3,
+    {ok, #{cert := Cert, key := _Key}} = R3,
     certificate_validation(Cert, <<"le.wtf">>, maps:get(san, Opts, [])),
 
     ok.


### PR DESCRIPTION
These changes make it possible to have multiple LetsEncrypt clients running.
This is useful for systems with more than one hostname. 

We use this now on the master branch of Zotonic.

Fix problem with 'valid' cert requests.
Fix problem with SANs when openssl conf file is a on a non-standard path.
