### PR TITLE
OTP-19 and openssl 1.0.x compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .eunit
+.rebar3
 deps
 *.o
 *.beam

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,6 @@ all:
 	./rebar3 compile
 
 dialize:
-	./rebar3 dialyzer;\
+	./rebar3 dialyzer
 
 .PHONY: dialize

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ all:
 	./rebar3 compile
 
 dialize:
-	if [[ "$$TRAVIS_OTP_RELEASE" > "18" ]] ; then\
-		./rebar3 dialyzer;\
-	fi
+	./rebar3 dialyzer;\
 
 .PHONY: dialize

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,7 @@ all:
 dialize:
 	./rebar3 dialyzer
 
+xref:
+	./rebar3 xref
+
 .PHONY: dialize

--- a/rebar.config
+++ b/rebar.config
@@ -12,23 +12,13 @@
 ]}.
 {deps, [
     {shotgun, "0.4.0"},
-    {jiffy  , "1.0.1"},
+    {jsx, "2.11.0"},
     {elli, "3.2.0"},
 
     % eletsencrypt escript dependencies
     {getopt         , "1.0.1"},
     {yamerl         , "0.7.0"},
     {erlang_color   , "1.0.0"}
-]}.
-
-{overrides, [
-    {override, jiffy, [
-        {plugins, [pc]},
-        {provider_hooks, [{post, [
-            {compile, {pc, compile}},
-            {clean, {pc, clean}}
-        ]}]}
-    ]}
 ]}.
 
 {xref_checks, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{minimum_otp_vsn, "22.2"}.
+%{minimum_otp_vsn, "22.2"}.
 {erl_opts, [
     debug_info,
     {warn_format, 2},

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-%{minimum_otp_vsn, "22.2"}.
+{minimum_otp_vsn, "19"}.
 {erl_opts, [
     debug_info,
     {warn_format, 2},

--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,12 @@
     ]}
 ]}.
 
+{xref_checks, [
+    undefined_function_calls,
+    locals_not_used,
+    deprecated_function_calls
+]}.
+
 {dialyzer, [
     % disable *no_match* and *no_unused* temporary
     %{warnings, [error_handling, race_conditions]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -5,7 +5,7 @@
  {<<"erlang_color">>,{pkg,<<"erlang_color">>,<<"1.0.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},0},
  {<<"gun">>,{pkg,<<"gun">>,<<"1.3.1">>},1},
- {<<"jiffy">>,{pkg,<<"jiffy">>,<<"1.0.1">>},0},
+ {<<"jsx">>,{pkg,<<"jsx">>,<<"2.11.0">>},0},
  {<<"shotgun">>,{pkg,<<"shotgun">>,<<"0.4.0">>},0},
  {<<"yamerl">>,{pkg,<<"yamerl">>,<<"0.7.0">>},0}]}.
 [
@@ -16,7 +16,7 @@
  {<<"erlang_color">>, <<"145FE1D2E65C4516E4F03FEFCA6C2F47EBAD5899D978D70382A5CFE643E4AC9E">>},
  {<<"getopt">>, <<"C73A9FA687B217F2FF79F68A3B637711BB1936E712B521D8CE466B29CBF7808A">>},
  {<<"gun">>, <<"1489FD96018431B89F401041A9CE0B02B45265247F0FDCF71273BF087C64EA4F">>},
- {<<"jiffy">>, <<"4F25639772CA41202F41BA9C8F6CA0933554283DD4742C90651E03471C55E341">>},
+ {<<"jsx">>, <<"08154624050333919B4AC1B789667D5F4DB166DC50E190C4D778D1587F102EE0">>},
  {<<"shotgun">>, <<"D9931B5F78C79169984C22F573032CCAFE03898C611DF360C0CC9D3756517746">>},
  {<<"yamerl">>, <<"E51DBA652DCE74C20A88294130B48051EBBBB0BE7D76F22DE064F0F3CCF0AAF5">>}]}
 ].

--- a/src/letsencrypt.app.src
+++ b/src/letsencrypt.app.src
@@ -6,7 +6,7 @@
    [kernel,
     stdlib,
     shotgun,
-    jiffy,
+    jsx,
     elli
    ]},
   {env,[]},

--- a/src/letsencrypt.erl
+++ b/src/letsencrypt.erl
@@ -84,7 +84,7 @@
 % returns:
 %	{ok, Pid}
 %
--spec start(list()) -> {'ok', pid}|{'error', {'already_started',pid()}}.
+-spec start(list()) -> {'ok', pid()}|{'error', {'already_started',pid()}}.
 start(Args) ->
     gen_fsm:start_link({global, ?MODULE}, ?MODULE, Args, []).
 

--- a/src/letsencrypt.erl
+++ b/src/letsencrypt.erl
@@ -37,7 +37,7 @@
         domain/0
     ]).
 
--define(WEBROOT_CHALLENGE_PATH, <<"/.well-known/acme-challenge">>).
+-define(WEBROOT_CHALLENGE_PATH, <<".well-known/acme-challenge">>).
 
 -record(state, {
 	% acme environment
@@ -538,7 +538,7 @@ setup_mode(State=#state{mode=webroot, webroot_path=Path}) ->
     %TODO: check directory is writeable
 	%TODO: handle errors
 	%TODO: protect against injections ?
-    os:cmd(string:join(["mkdir -p '", Path, str(?WEBROOT_CHALLENGE_PATH), "'"], "")),
+    ok = filelib:ensure_dir(filename:join([ Path, ?WEBROOT_CHALLENGE_PATH, "x" ])),
 	State;
 setup_mode(State=#state{mode=standalone, port=_Port}) ->
 	%TODO: checking port is unused ?
@@ -697,8 +697,8 @@ challenge_init(webroot, #state{webroot_path=WPath, account_key=AccntKey}, 'http-
     maps:fold(
         fun(_K, #{<<"token">> := Token}, _Acc) ->
 			Thumbprint = letsencrypt_jws:keyauth(AccntKey, Token),
-            file:write_file(<<(bin(WPath))/binary, $/, ?WEBROOT_CHALLENGE_PATH/binary, $/, Token/binary>>,
-                            Thumbprint)
+            ThumbPrintFile = filename:join([WPath, ?WEBROOT_CHALLENGE_PATH, Token]),
+            file:write_file(ThumbPrintFile, Thumbprint)
         end,
         0, Challenges
     );
@@ -749,7 +749,8 @@ challenge_init(standalone, #state{port=Port, domain=Domain, account_key=AccntKey
 -spec challenge_destroy(mode(), state()) -> ok.
 challenge_destroy(webroot, #state{webroot_path=WPath, challenges=Challenges}) ->
     maps:fold(fun(_K, #{<<"token">> := Token}, _) ->
-        file:delete(<<(bin(WPath))/binary, $/, ?WEBROOT_CHALLENGE_PATH/binary, $/, Token/binary>>)
+        ThumbPrintFile = filename:join([WPath, ?WEBROOT_CHALLENGE_PATH, Token]),
+        file:delete(ThumbPrintFile)
     end, 0, Challenges),
     ok;
 challenge_destroy(standalone, _) ->

--- a/src/letsencrypt.erl
+++ b/src/letsencrypt.erl
@@ -31,6 +31,11 @@
 -type jws()            :: #{'alg' => 'RS256', 'jwk' => map(), nonce => undefined|letsencrypt:nonce() }.
 -type ssl_privatekey() :: #{'raw' => crypto:rsa_private(), 'b64' => {binary(), binary()}, 'file' => string()}.
 
+-type domain()         :: binary() | string().
+
+-export_type([
+        domain/0
+    ]).
 
 -define(WEBROOT_CHALLENGE_PATH, <<"/.well-known/acme-challenge">>).
 
@@ -555,11 +560,11 @@ setup_mode(#state{mode=Mode}) ->
 %   - {error, Err} if another error
 %   - 'ok' if succeed
 %
--spec wait_valid(0..10) -> ok|{error, any()}.
+-spec wait_valid(0..20) -> ok|{error, any()}.
 wait_valid(X) ->
     wait_valid(X,X).
 
--spec wait_valid(0..10, 0..10) -> ok|{error, any()}.
+-spec wait_valid(0..20, 0..20) -> ok|{error, any()}.
 wait_valid(0,_) ->
     {error, timeout};
 wait_valid(Cnt,Max) ->
@@ -581,11 +586,11 @@ wait_valid(Cnt,Max) ->
 %   - {error, Err} if another error
 %   - {'ok', Response} if succeed
 %
--spec wait_finalized(atom(), 0..10) -> {ok, map()}|{error, timeout|any()}.
+-spec wait_finalized(atom(), 0..20) -> {ok, map()}|{error, timeout|any()}.
 wait_finalized(Status, X) ->
     wait_finalized(Status,X,X).
 
--spec wait_finalized(atom(), 0..10, 0..10) -> {ok, map()}|{error, timeout|any()}.
+-spec wait_finalized(atom(), 0..20, 0..20) -> {ok, map()}|{error, timeout|any()}.
 wait_finalized(_, 0,_) ->
     {error, timeout};
 wait_finalized(Status, Cnt,Max) ->

--- a/src/letsencrypt_ssl.erl
+++ b/src/letsencrypt_ssl.erl
@@ -99,8 +99,8 @@ mkcert(Type, Domain, OutName, Keyfile, SANs) ->
     ConfDir = filename:dirname(OutName),
     ConfFile = filename:join(ConfDir, "letsencrypt_san_openssl." ++ letsencrypt_utils:str(Domain) ++ ".cnf"),
     ok = file:write_file(ConfFile, Cnf),
-    Cmd = io_lib:format("openssl req -new -key '~s' -sha256 -out '~s' -subj '/CN=~s' -config '~s'",
-                        [Keyfile, OutName, Domain, ConfFile]),
+    Cmd = io_lib:format("openssl req -new -key '~s' -sha256 -out '~s' -config '~s'",
+                        [Keyfile, OutName, ConfFile]),
     Cmd1 = case Type of
         request    -> [Cmd | " -reqexts v3_req" ];
         autosigned -> [Cmd | " -extensions v3_req -x509 -days 1" ]

--- a/src/letsencrypt_ssl.erl
+++ b/src/letsencrypt_ssl.erl
@@ -51,7 +51,7 @@ private_key(KeyFile, _) ->
 cert_request(Domain, CertsPath, SANs) ->
     KeyFile  = CertsPath ++ "/" ++ Domain ++ ".key",
     CertFile = CertsPath ++ "/" ++ Domain ++ ".csr",
-    {ok, CertFile} = mkcert(Domain, CertFile, KeyFile, SANs),
+    {ok, CertFile} = mkcert(request, Domain, CertFile, KeyFile, SANs),
     %io:format("CSR ~p~n", [CertFile]),
 
     case file:read_file(CertFile) of

--- a/src/letsencrypt_ssl.erl
+++ b/src/letsencrypt_ssl.erl
@@ -18,10 +18,9 @@
 -export([private_key/2, cert_request/3, cert_autosigned/3, certificate/3]).
 
 -include_lib("public_key/include/public_key.hrl").
-% -import(letsencrypt_utils, [bin/1]).
 
 % create key
--spec private_key(undefined|{new, string()}|string(), string()) -> letsencrypt:ssl_privatekey().
+-spec private_key(undefined|{new, file:filename_all()}|file:filename_all(), file:filename_all()) -> letsencrypt:ssl_privatekey().
 private_key(undefined, CertsPath) ->
     private_key({new, "letsencrypt.key"}, CertsPath);
 
@@ -29,14 +28,12 @@ private_key({new, KeyFile}, CertsPath) ->
     FileName = CertsPath++"/"++KeyFile,
     Cmd = "openssl genrsa -out '"++FileName++"' 2048",
     _R = os:cmd(Cmd),
-
     private_key(FileName, CertsPath);
 
 private_key(KeyFile, _) ->
     {ok, Pem} = file:read_file(KeyFile),
     [Key]     = public_key:pem_decode(Pem),
     #'RSAPrivateKey'{modulus=N, publicExponent=E, privateExponent=D} = public_key:pem_entry_decode(Key),
-
     #{
         raw => [E,N,D],
         b64 => {
@@ -47,18 +44,14 @@ private_key(KeyFile, _) ->
     }.
 
 
--spec cert_request(string(), string(), list(string())) -> letsencrypt:ssl_csr().
+-spec cert_request(letsencrypt:domain(), file:filename_all(), list(letsencrypt:domain())) -> letsencrypt:ssl_csr().
 cert_request(Domain, CertsPath, SANs) ->
     KeyFile  = CertsPath ++ "/" ++ Domain ++ ".key",
     CertFile = CertsPath ++ "/" ++ Domain ++ ".csr",
     {ok, CertFile} = mkcert(request, Domain, CertFile, KeyFile, SANs),
-    %io:format("CSR ~p~n", [CertFile]),
-
     case file:read_file(CertFile) of
         {ok, RawCsr} ->
             [{'CertificationRequest', Csr, not_encrypted}] = public_key:pem_decode(RawCsr),
-
-            %io:format("csr= ~p~n", [Csr]),
             letsencrypt_utils:b64encode(Csr);
         {error, enoent} ->
             io:format("cert_request: cert file ~p not found~n", [CertFile]),
@@ -68,46 +61,22 @@ cert_request(Domain, CertsPath, SANs) ->
             throw(unknown_error)
     end.
 
-% % create temporary (1 day) certificate with subjectAlternativeName
-% % used for tls-sni-01 challenge
-% -spec cert_autosigned(string(), string(), list(string())) -> {ok, string()}.
-% cert_autosigned(Domain, KeyFile, SANs) ->
-%     CertFile = "/tmp/"++Domain++"-tlssni-autosigned.pem",
-%     mkcert(request, Domain, CertFile, KeyFile, SANs).
-
-
-% -spec mkcert(request|autosigned, string(), string(), string(), list(string())) -> {ok, string()}.
-% mkcert(request, Domain, OutName, Keyfile, SANs) ->
-%     AltNames = lists:foldl(fun(San, Acc) ->
-%         <<Acc/binary, ", DNS:", San/binary>>
-%     end, <<"subjectAltName=DNS:", (bin(Domain))/binary>>, SANs),
-%     Cmd = io_lib:format("openssl req -new -key '~s' -out '~s' -subj '/CN=~s' -addext '~s'",
-%                         [Keyfile, OutName, Domain, AltNames]),
-
-%     _Status  = os:cmd(Cmd),
-%     %io:format("mkcert(request):~p => ~p~n", [lists:flatten(Cmd), _Status]),
-%     {ok, OutName}.
-
 % domain certificate only
 certificate(Domain, DomainCert, CertsPath) ->
     FileName = CertsPath++"/"++Domain++".crt",
     file:write_file(FileName, DomainCert),
     FileName.
 
-
 % create temporary (1 day) certificate with subjectAlternativeName
 % used for tls-sni-01 challenge
--spec cert_autosigned(string(), string(), list(string())) -> {ok, string()}.
+-spec cert_autosigned(letsencrypt:domain(), file:filename_all(), list(letsencrypt:domain())) -> {ok, file:filename_all()}.
 cert_autosigned(Domain, KeyFile, SANs) ->
-    CertFile = "/tmp/"++Domain++"-tlssni-autosigned.pem",
+    KeyDir = filename:dirname(KeyFile),
+    CertFile = filename:join(KeyDir, <<(letsencrypt_utils:bin(Domain))/binary, "-tlssni-autosigned.pem">>),
     mkcert(autosigned, Domain, CertFile, KeyFile, SANs).
 
 
--spec mkcert(request|autosigned, string(), string(), string(), list(string())) -> {ok, string()}.
-mkcert(request, Domain, OutName, Keyfile, []) ->
-    Cmd = io_lib:format("openssl req -new -key '~s' -sha256 -subj '/CN=~s' -out '~s'", [Keyfile, Domain, OutName]),
-    _R  = os:cmd(Cmd),
-    {ok, OutName};
+-spec mkcert(request|autosigned, letsencrypt:domain(), file:filename_all(), file:filename_all(), list(letsencrypt:domain())) -> {ok, file:filename_all()}.
 mkcert(Type, Domain, OutName, Keyfile, SANs) ->
     Names = [ Domain | SANs ],
     NamesNr = lists:zip(Names, lists:seq(1,length(Names))),
@@ -124,7 +93,8 @@ mkcert(Type, Domain, OutName, Keyfile, SANs) ->
     ] ++ [
         [ "DNS.", integer_to_list(Nr), " = ", Name, "\n" ] || {Name, Nr} <- NamesNr
     ],
-    ConfFile = <<"/tmp/letsencrypt_san_openssl.",(iolist_to_binary(Domain))/binary ,".cnf">>,
+    ConfDir = filename:dirname(OutName),
+    ConfFile = filename:join(ConfDir, <<"letsencrypt_san_openssl.", (letsencrypt_utils:bin(Domain))/binary ,".cnf">>),
     ok = file:write_file(ConfFile, Cnf),
     Cmd = io_lib:format("openssl req -new -key '~s' -sha256 -out '~s' -subj '/CN=~s' -config '~s'", 
                         [Keyfile, OutName, Domain, ConfFile]),

--- a/src/letsencrypt_utils.erl
+++ b/src/letsencrypt_utils.erl
@@ -15,7 +15,7 @@
 -module(letsencrypt_utils).
 -author("Guillaume Bour <guillaume@bour.cc>").
 
--export([b64encode/1, hexdigest/1, hashdigest/2, bin/1, str/1]).
+-export([b64encode/1, hexdigest/1, hashdigest/2, str/1]).
 
 -type character() :: integer().
 
@@ -43,22 +43,9 @@ hex(C)             -> $a + C - 10.
 hashdigest(sha256, Content) ->
 	hexdigest(crypto:hash(sha256, Content)).
 
--spec bin(binary()|string()) -> binary().
-bin(X) when is_binary(X) ->
-    X;
-bin(X) when is_list(X) ->
-    list_to_binary(X);
-bin(X) when is_atom(X) ->
-    erlang:atom_to_binary(X, utf8);
-bin(_X) ->
-    throw(invalid).
-
-
--spec str(binary()) -> string().
+-spec str( binary() | string() ) -> string().
 str(X) when is_binary(X) ->
-    binary_to_list(X);
-str(X) when is_integer(X) ->
-    integer_to_list(X);
+    unicode:characters_to_list(X);
 str(X) when is_list(X) ->
 	X;
 str(_X) ->

--- a/src/letsencrypt_utils.erl
+++ b/src/letsencrypt_utils.erl
@@ -15,7 +15,7 @@
 -module(letsencrypt_utils).
 -author("Guillaume Bour <guillaume@bour.cc>").
 
--export([b64encode/1, hexdigest/1, hashdigest/2, str/1]).
+-export([b64encode/1, hexdigest/1, hashdigest/2, bin/1, str/1]).
 
 -type character() :: integer().
 
@@ -42,6 +42,15 @@ hex(C)             -> $a + C - 10.
 -spec hashdigest(sha256, binary()) -> binary().
 hashdigest(sha256, Content) ->
 	hexdigest(crypto:hash(sha256, Content)).
+
+
+-spec bin( binary() | string() ) -> binary().
+bin(X) when is_list(X) ->
+    unicode:characters_to_binary(X);
+bin(X) when is_binary(X) ->
+    X;
+bin(_X) ->
+    throw(invalid).
 
 -spec str( binary() | string() ) -> string().
 str(X) when is_binary(X) ->

--- a/src/letsencrypt_utils.erl
+++ b/src/letsencrypt_utils.erl
@@ -44,17 +44,21 @@ hashdigest(sha256, Content) ->
 	hexdigest(crypto:hash(sha256, Content)).
 
 
--spec bin( binary() | string() ) -> binary().
-bin(X) when is_list(X) ->
-    unicode:characters_to_binary(X);
+-spec bin( binary() | string() | atom() ) -> binary().
 bin(X) when is_binary(X) ->
     X;
+bin(X) when is_list(X) ->
+    unicode:characters_to_binary(X);
+bin(X) when is_atom(X) ->
+    erlang:atom_to_binary(X, utf8);
 bin(_X) ->
     throw(invalid).
 
--spec str( binary() | string() ) -> string().
+-spec str( binary() | string() | integer() ) -> string().
 str(X) when is_binary(X) ->
     unicode:characters_to_list(X);
+str(X) when is_integer(X) ->
+    integer_to_list(X);
 str(X) when is_list(X) ->
 	X;
 str(_X) ->


### PR DESCRIPTION
This changes a couple of things:

 * Sets min OTP version to 19, as it does indeed work excellent with OTP-19
 * Uses the openssl 1.0.x code to add the SANs to the certificate, as quite some machines are still using a late version of openssl 1.0.x
 * Enables the Dialyzer Makefile target
 * Small start with additional typing of arguments